### PR TITLE
FULLTEXT, BLOB, enum/set and a few bits

### DIFF
--- a/db_converter.py
+++ b/db_converter.py
@@ -26,7 +26,9 @@ def parse(input_filename, output_filename):
     tables = {}
     current_table = None
     creation_lines = []
+    enum_types = []
     foreign_key_lines = []
+    fulltext_key_lines = []
     sequence_lines = []
     cast_lines = []
     num_inserts = 0
@@ -77,7 +79,6 @@ def parse(input_filename, output_filename):
             # Start of a table creation statement?
             if line.startswith("CREATE TABLE"):
                 current_table = line.split('"')[1]
-                output.write("CREATE TABLE \"%s\" (\n" % current_table)
                 tables[current_table] = {"columns": []}
                 creation_lines = []
             # Inserting data into a table?
@@ -95,19 +96,30 @@ def parse(input_filename, output_filename):
                 useless, name, definition = line.strip(",").split('"',2)
                 try:
                     type, extra = definition.strip().split(" ", 1)
+
+                    # This must be a tricky enum
+                    if ')' in extra:
+                        type, extra = definition.strip().split(")")
+
                 except ValueError:
                     type = definition.strip()
                     extra = ""
                 extra = re.sub("CHARACTER SET [\w\d]+\s*", "", extra.replace("unsigned", ""))
+                extra = re.sub("COLLATE [\w\d]+\s*", "", extra.replace("unsigned", ""))
+
                 # See if it needs type conversion
                 final_type = None
+                set_sequence = None
                 if type == "tinyint(1)":
                     type = "int4"
+                    set_sequence = True
                     final_type = "boolean"
                 elif type.startswith("int("):
                     type = "integer"
+                    set_sequence = True
                 elif type.startswith("bigint("):
                     type = "bigint"
+                    set_sequence = True
                 elif type == "longtext":
                     type = "text"
                 elif type == "mediumtext":
@@ -119,14 +131,32 @@ def parse(input_filename, output_filename):
                     type = "varchar(%s)" % (size * 2)
                 elif type.startswith("smallint("):
                     type = "int2"
+                    set_sequence = True
                 elif type == "datetime":
                     type = "timestamp with time zone"
                 elif type == "double":
                     type = "double precision"
+                elif type == "blob":
+                    type = "bytea"
+                elif type.startswith("enum(") or type.startswith("set("):
+
+                    types_str = type.split("(")[1].rstrip(")").rstrip('"')
+                    types_arr = [type_str.strip('\'') for type_str in types_str.split(",")]
+
+                    # Considered using values to make a name, but its dodgy
+                    # enum_name = '_'.join(types_arr)
+                    enum_name = "{0}_{1}".format(current_table, name)
+
+                    if enum_name not in enum_types:
+                        output.write("CREATE TYPE {0} AS ENUM ({1}); \n".format(enum_name, types_str));
+                        enum_types.append(enum_name)
+
+                    type = enum_name
+
                 if final_type:
                     cast_lines.append("ALTER TABLE \"%s\" ALTER COLUMN \"%s\" DROP DEFAULT, ALTER COLUMN \"%s\" TYPE %s USING CAST(\"%s\" as %s)" % (current_table, name, name, final_type, name, final_type))
-                # ID fields need sequences
-                if name == "id":
+                # ID fields need sequences [if they are integers?]
+                if name == "id" and set_sequence is True:
                     sequence_lines.append("CREATE SEQUENCE %s_id_seq" % (current_table))
                     sequence_lines.append("SELECT setval('%s_id_seq', max(id)) FROM %s" % (current_table, current_table))
                     sequence_lines.append("ALTER TABLE \"%s\" ALTER COLUMN \"id\" SET DEFAULT nextval('%s_id_seq')" % (current_table, current_table))
@@ -141,10 +171,16 @@ def parse(input_filename, output_filename):
                 foreign_key_lines.append("CREATE INDEX ON \"%s\" %s" % (current_table, line.split("FOREIGN KEY")[1].split("REFERENCES")[0].strip().rstrip(",")))
             elif line.startswith("UNIQUE KEY"):
                 creation_lines.append("UNIQUE (%s)" % line.split("(")[1].split(")")[0])
+            elif line.startswith("FULLTEXT KEY"):
+
+                fulltext_keys = " || ' ' || ".join( line.split('(')[-1].split(')')[0].replace('"', '').split(',') )
+                fulltext_key_lines.append("CREATE INDEX ON %s USING gin(to_tsvector('english', %s))" % (current_table, fulltext_keys))
+
             elif line.startswith("KEY"):
                 pass
             # Is it the end of the table?
             elif line == ");":
+                output.write("CREATE TABLE \"%s\" (\n" % current_table)
                 for i, line in enumerate(creation_lines):
                     output.write("    %s%s\n" % (line, "," if i != (len(creation_lines) - 1) else ""))
                 output.write(');\n\n')
@@ -172,6 +208,11 @@ def parse(input_filename, output_filename):
     # Write sequences out
     output.write("\n-- Sequences --\n")
     for line in sequence_lines:
+        output.write("%s;\n" % line)
+
+    # Write full-text indexkeyses out
+    output.write("\n-- Full Text keys --\n")
+    for line in fulltext_key_lines:
         output.write("%s;\n" % line)
 
     # Finish file


### PR DESCRIPTION
While working on a mysql -> pgsql conversion for a PyroCMS application I required some functionality not covered by this script.

Fulltext keys are now supported, which required delaying the output of CREATE TABLE until the end of the table generation - but no matter.

Enum/Set columns will now generate their own "types", so the same functionality is kept as in MySQL. 

I also implemented two pull requests #11 and #12 as they were required to get the DB converted. You can merge this one and close theirs.
