### PR TITLE
non-unique / non-foreign key indexes, case sensitive columns, ignore triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ How to use
 First, dump your MySQL database in PostgreSQL-compatible format
 
     mysqldump --compatible=postgresql --default-character-set=utf8 \
-    -r databasename.mysql -u root databasename
+    --skip-triggers -r databasename.mysql -u root databasename
 
 Then, convert it using the dbconverter.py script
 
@@ -22,7 +22,7 @@ Then, convert it using the dbconverter.py script
 
 It'll print progress to the terminal.
 
-Finally, load your new dump into a fresh PostgreSQL database using: 
+Finally, load your new dump into a fresh PostgreSQL database using:
 
 `psql -f databasename.psql`
 
@@ -30,3 +30,7 @@ More information
 ----------------
 
 You can learn more about the move which this powered at http://lanyrd.com/blog/2012/lanyrds-big-move/ and some technical details of it at http://www.aeracode.org/2012/11/13/one-change-not-enough/.
+
+The script does not cope with triggers so we include --skip-triggers
+on the mysqldump command. You will need to manually convert any triggers you
+have.

--- a/db_converter.py
+++ b/db_converter.py
@@ -92,13 +92,15 @@ def parse(input_filename, output_filename):
         else:
             # Is it a column?
             if line.startswith('"'):
-                useless, name, definition = line.strip(",").split('"',2)
+                useless, name, definition = line.strip(",").split('"', 2)
                 try:
                     type, extra = definition.strip().split(" ", 1)
                 except ValueError:
                     type = definition.strip()
                     extra = ""
                 extra = re.sub("CHARACTER SET [\w\d]+\s*", "", extra.replace("unsigned", ""))
+                # utf8_bin collation causes an error and usually is a no-op for postgres
+                extra = extra.replace("COLLATE utf8_bin", "")
                 # See if it needs type conversion
                 final_type = None
                 if type == "tinyint(1)":


### PR DESCRIPTION
Include non-unique, non-foreign-key indexes.  I.e. when you set db_index=True on your column definition.

It isn't uncommon to add "COLLATE utf8_bin" on a mysql column to make it case sensitive in mysql (although Django doesn't make this easy), and prior to these changes this causes the script to emit invalid SQL.  Postgres is case sensitive by default, so its reasonable just to ignore COLLATE utf8_bin.  

The script doesn't cope with triggers, and they look pretty hard to convert automatically.  So update readme to suggest --skip-triggers.  Otherwise triggers cause the script to fail
