### PR TITLE
Convert column names to lowercase

### DIFF
--- a/db_converter.py
+++ b/db_converter.py
@@ -94,6 +94,7 @@ def parse(input_filename, output_filename):
             # Is it a column?
             if line.startswith('"'):
                 useless, name, definition = line.strip(",").split('"',2)
+                name = name.lower() # postgres converts to lowercase anyway
                 try:
                     type, extra = definition.strip().split(" ", 1)
 


### PR DESCRIPTION
I had to convert an old web application using PHP and Mysql to Postgresql. In the process I learned MySQL has case-sensitive columns whereas Postgres converts to lower case and then match against the DB. In my case it was easier to have columns in lower case, so the legacy code with upper case would work as expected. It would have been more work to add quotes in the code, so here is a possible solution for this cases.
