### PR TITLE
pep8 cleanup. "support" for drop table if exists. drop sequences before creation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Python bytecode:
+*.py[co]
+

--- a/db_converter.py
+++ b/db_converter.py
@@ -112,9 +112,8 @@ def parse(input_filename, output_filename):
                 final_type = None
                 set_sequence = None
                 if type == "tinyint(1)":
-                    type = "int4"
+                    type = "int2"
                     set_sequence = True
-                    final_type = "boolean"
                 elif type.startswith("tinyint("):
                     type = "int2"
                     set_sequence = True

--- a/db_converter.py
+++ b/db_converter.py
@@ -71,7 +71,7 @@ def parse(input_filename, output_filename):
         logging.flush()
         line = line.decode("utf8").strip().replace(r"\\", "WUBWUBREALSLASHWUB").replace(r"\'", "''").replace("WUBWUBREALSLASHWUB", r"\\")
         # Ignore comment lines
-        if line.startswith("--") or line.startswith("/*") or line.startswith("LOCK TABLES") or line.startswith("DROP TABLE") or line.startswith("UNLOCK TABLES") or not line:
+        if line.startswith("--") or line.startswith("/*") or line.startswith("LOCK TABLES") or line.startswith("UNLOCK TABLES") or not line:
             continue
 
         # Outside of anything handling

--- a/db_converter.py
+++ b/db_converter.py
@@ -48,7 +48,6 @@ def parse(input_filename, output_filename):
     else:
         input_fh = open(input_filename)
 
-
     output.write("-- Converted by db_converter\n")
     output.write("START TRANSACTION;\n")
     output.write("SET standard_conforming_strings=off;\n")
@@ -57,12 +56,12 @@ def parse(input_filename, output_filename):
 
     for i, line in enumerate(input_fh):
         time_taken = time.time() - started
-        percentage_done = (i+1) / float(num_lines)
+        percentage_done = (i + 1) / float(num_lines)
         secs_left = (time_taken / percentage_done) - time_taken
         logging.write("\rLine %i (of %s: %.2f%%) [%s tables] [%s inserts] [ETA: %i min %i sec]" % (
             i + 1,
             num_lines,
-            ((i+1)/float(num_lines))*100,
+            ((i + 1) / float(num_lines)) * 100,
             len(tables),
             num_inserts,
             secs_left // 60,
@@ -95,7 +94,7 @@ def parse(input_filename, output_filename):
         else:
             # Is it a column?
             if line.startswith('"'):
-                useless, name, definition = line.strip(",").split('"',2)
+                useless, name, definition = line.strip(",").split('"', 2)
                 try:
                     type, extra = definition.strip().split(" ", 1)
 
@@ -150,7 +149,7 @@ def parse(input_filename, output_filename):
                     enum_name = "{0}_{1}".format(current_table, name)
 
                     if enum_name not in enum_types:
-                        output.write("CREATE TYPE {0} AS ENUM ({1}); \n".format(enum_name, types_str));
+                        output.write("CREATE TYPE {0} AS ENUM ({1}); \n".format(enum_name, types_str))
                         enum_types.append(enum_name)
 
                     type = enum_name
@@ -176,7 +175,7 @@ def parse(input_filename, output_filename):
                 creation_lines.append("UNIQUE (%s)" % line.split("(")[1].split(")")[0])
             elif line.startswith("FULLTEXT KEY"):
 
-                fulltext_keys = " || ' ' || ".join( line.split('(')[-1].split(')')[0].replace('"', '').split(',') )
+                fulltext_keys = " || ' ' || ".join(line.split('(')[-1].split(')')[0].replace('"', '').split(','))
                 fulltext_key_lines.append("CREATE INDEX ON %s USING gin(to_tsvector('english', %s))" % (current_table, fulltext_keys))
 
             elif line.startswith("KEY"):
@@ -191,7 +190,6 @@ def parse(input_filename, output_filename):
             # ???
             else:
                 print "\n ! Unknown line inside table creation: %s" % line
-
 
     # Finish file
     output.write("\n-- Post-data save --\n")

--- a/db_converter.py
+++ b/db_converter.py
@@ -115,6 +115,9 @@ def parse(input_filename, output_filename):
                     type = "int4"
                     set_sequence = True
                     final_type = "boolean"
+                elif type.startswith("tinyint("):
+                    type = "int2"
+                    set_sequence = True
                 elif type.startswith("int("):
                     type = "integer"
                     set_sequence = True

--- a/db_converter.py
+++ b/db_converter.py
@@ -159,6 +159,7 @@ def parse(input_filename, output_filename):
                     cast_lines.append("ALTER TABLE \"%s\" ALTER COLUMN \"%s\" DROP DEFAULT, ALTER COLUMN \"%s\" TYPE %s USING CAST(\"%s\" as %s)" % (current_table, name, name, final_type, name, final_type))
                 # ID fields need sequences [if they are integers?]
                 if name == "id" and set_sequence is True:
+                    sequence_lines.append("DROP SEQUENCE IF EXISTS %s_id_seq" % (current_table))
                     sequence_lines.append("CREATE SEQUENCE %s_id_seq" % (current_table))
                     sequence_lines.append("SELECT setval('%s_id_seq', max(id)) FROM %s" % (current_table, current_table))
                     sequence_lines.append("ALTER TABLE \"%s\" ALTER COLUMN \"id\" SET DEFAULT nextval('%s_id_seq')" % (current_table, current_table))

--- a/db_converter.py
+++ b/db_converter.py
@@ -82,7 +82,7 @@ def parse(input_filename, output_filename):
                 creation_lines = []
             # Inserting data into a table?
             elif line.startswith("INSERT INTO"):
-                output.write(line.encode("utf8").replace("'0000-00-00 00:00:00'", "NULL") + "\n")
+                output.write(re.sub(r"'0000-00-00 00:00:00(\.[0]+)?'", "'1970-01-01 00:00:00'", line.encode("utf8")) + "\n")
                 num_inserts += 1
             # ???
             elif line.startswith("DROP TABLE"):
@@ -162,7 +162,7 @@ def parse(input_filename, output_filename):
                 if name == "id" and set_sequence is True:
                     sequence_lines.append("DROP SEQUENCE IF EXISTS %s_id_seq" % (current_table))
                     sequence_lines.append("CREATE SEQUENCE %s_id_seq" % (current_table))
-                    sequence_lines.append("SELECT setval('%s_id_seq', max(id)) FROM %s" % (current_table, current_table))
+                    sequence_lines.append("SELECT setval('%s_id_seq', max(id)) FROM \"%s\"" % (current_table, current_table))
                     sequence_lines.append("ALTER TABLE \"%s\" ALTER COLUMN \"id\" SET DEFAULT nextval('%s_id_seq')" % (current_table, current_table))
                 # Record it
                 creation_lines.append('"%s" %s %s' % (name, type, extra))

--- a/db_converter.py
+++ b/db_converter.py
@@ -48,6 +48,7 @@ def parse(input_filename, output_filename):
     else:
         input_fh = open(input_filename)
 
+
     output.write("-- Converted by db_converter\n")
     output.write("START TRANSACTION;\n")
     output.write("SET standard_conforming_strings=off;\n")
@@ -70,10 +71,8 @@ def parse(input_filename, output_filename):
         logging.flush()
         line = line.decode("utf8").strip().replace(r"\\", "WUBWUBREALSLASHWUB").replace(r"\'", "''").replace("WUBWUBREALSLASHWUB", r"\\")
         # Ignore comment lines
-        if line.startswith("--") or line.startswith("/*") or line.startswith("LOCK TABLES") or line.startswith("UNLOCK TABLES") or not line:
+        if line.startswith("--") or line.startswith("/*") or line.startswith("LOCK TABLES") or line.startswith("DROP TABLE") or line.startswith("UNLOCK TABLES") or not line:
             continue
-        if line.startswith("DROP TABLE"):
-            line = line.decode("utf8").strip().replace("DROP TABLE IF EXISTS", "DROP IF EXISTS")
 
         # Outside of anything handling
         if current_table is None:
@@ -87,7 +86,7 @@ def parse(input_filename, output_filename):
                 output.write(line.encode("utf8").replace("'0000-00-00 00:00:00'", "NULL") + "\n")
                 num_inserts += 1
             # ???
-            elif line.startswith("DROP IF EXISTS"):
+            elif line.startswith("DROP TABLE"):
                 output.write(line.encode("utf8") + "\n")
             else:
                 print "\n ! Unknown line in main body: %s" % line

--- a/db_converter.py
+++ b/db_converter.py
@@ -48,7 +48,6 @@ def parse(input_filename, output_filename):
     else:
         input_fh = open(input_filename)
 
-
     output.write("-- Converted by db_converter\n")
     output.write("START TRANSACTION;\n")
     output.write("SET standard_conforming_strings=off;\n")
@@ -71,8 +70,10 @@ def parse(input_filename, output_filename):
         logging.flush()
         line = line.decode("utf8").strip().replace(r"\\", "WUBWUBREALSLASHWUB").replace(r"\'", "''").replace("WUBWUBREALSLASHWUB", r"\\")
         # Ignore comment lines
-        if line.startswith("--") or line.startswith("/*") or line.startswith("LOCK TABLES") or line.startswith("DROP TABLE") or line.startswith("UNLOCK TABLES") or not line:
+        if line.startswith("--") or line.startswith("/*") or line.startswith("LOCK TABLES") or line.startswith("UNLOCK TABLES") or not line:
             continue
+        if line.startswith("DROP TABLE"):
+            line = line.decode("utf8").strip().replace("DROP TABLE IF EXISTS", "DROP IF EXISTS")
 
         # Outside of anything handling
         if current_table is None:
@@ -86,6 +87,8 @@ def parse(input_filename, output_filename):
                 output.write(line.encode("utf8").replace("'0000-00-00 00:00:00'", "NULL") + "\n")
                 num_inserts += 1
             # ???
+            elif line.startswith("DROP IF EXISTS"):
+                output.write(line.encode("utf8") + "\n")
             else:
                 print "\n ! Unknown line in main body: %s" % line
 

--- a/db_converter.py
+++ b/db_converter.py
@@ -68,7 +68,7 @@ def parse(input_filename, output_filename):
             secs_left % 60,
         ))
         logging.flush()
-        line = line.decode("utf8").strip().replace(r"\\", "WUBWUBREALSLASHWUB").replace(r"\'", "''").replace("WUBWUBREALSLASHWUB", r"\\")
+        line = line.decode("utf8", 'replace').strip().replace(r"\\", "WUBWUBREALSLASHWUB").replace(r"\'", "''").replace("WUBWUBREALSLASHWUB", r"\\")
         # Ignore comment lines
         if line.startswith("--") or line.startswith("/*") or line.startswith("LOCK TABLES") or line.startswith("UNLOCK TABLES") or not line:
             continue


### PR DESCRIPTION
We have multiple DBs/types we import on a nightly basis into an analytics dashboard. These changes allow mysql DBs to be ingested over and over without having to drop the database every time.

These should not be destructive for other use cases but feedback is welcome. Thought I'd offer this upstream in case you thought it was useful.
