### PR TITLE
Avoid rewriting quoted SQL

### DIFF
--- a/db_converter.py
+++ b/db_converter.py
@@ -83,7 +83,7 @@ def parse(input_filename, output_filename):
                 creation_lines = []
             # Inserting data into a table?
             elif line.startswith("INSERT INTO"):
-                output.write(line.encode("utf8").replace("'0000-00-00 00:00:00'", "NULL") + "\n")
+                output.write(re.sub(r"([^'])'0000-00-00 00:00:00'", r"\1NULL", line.encode("utf8")) + "\n")
                 num_inserts += 1
             # ???
             else:


### PR DESCRIPTION
If your database contains text fields which contain

```
'0000-00-00 00:00:00'
```

then the existing search/replace with NULL would create syntax errors by accidentally closing the quotes.

```
'\'0000-00-00 00:00:00\'' # one string, from MySQL
'''0000-00-00 00:00:00''' # one string, after replacing \' with ''
''NULL''                  # syntax error: string NULL string
```

This change should avoid this problem.
