### PR TITLE
Managing double(x,y) scenarios

### DIFF
--- a/db_converter.py
+++ b/db_converter.py
@@ -134,6 +134,9 @@ def parse(input_filename, output_filename):
                     set_sequence = True
                 elif type == "datetime":
                     type = "timestamp with time zone"
+                elif type.startswith("double("):
+                    size = (type.split("(")[1].rstrip(")"))
+                    type = "numeric(%s)" % (size)    
                 elif type == "double":
                     type = "double precision"
                 elif type == "blob":


### PR DESCRIPTION
Mysql double(x,y) scenarios was throwing an error, so what I'm doing now is to find the "double(" string and change it to numeric(x,y)
