### PR TITLE
Quote table names during sequence and fulltext key creation

### DIFF
--- a/db_converter.py
+++ b/db_converter.py
@@ -158,7 +158,7 @@ def parse(input_filename, output_filename):
                 # ID fields need sequences [if they are integers?]
                 if name == "id" and set_sequence is True:
                     sequence_lines.append("CREATE SEQUENCE %s_id_seq" % (current_table))
-                    sequence_lines.append("SELECT setval('%s_id_seq', max(id)) FROM %s" % (current_table, current_table))
+                    sequence_lines.append("SELECT setval('%s_id_seq', max(id)) FROM \"%s\"" % (current_table, current_table))
                     sequence_lines.append("ALTER TABLE \"%s\" ALTER COLUMN \"id\" SET DEFAULT nextval('%s_id_seq')" % (current_table, current_table))
                 # Record it
                 creation_lines.append('"%s" %s %s' % (name, type, extra))
@@ -174,7 +174,7 @@ def parse(input_filename, output_filename):
             elif line.startswith("FULLTEXT KEY"):
 
                 fulltext_keys = " || ' ' || ".join( line.split('(')[-1].split(')')[0].replace('"', '').split(',') )
-                fulltext_key_lines.append("CREATE INDEX ON %s USING gin(to_tsvector('english', %s))" % (current_table, fulltext_keys))
+                fulltext_key_lines.append("CREATE INDEX ON \"%s\" USING gin(to_tsvector('english', %s))" % (current_table, fulltext_keys))
 
             elif line.startswith("KEY"):
                 pass


### PR DESCRIPTION
Hi all - thanks for the very useful migration script. Played with it today, noticed a couple of table names that weren't being quoted. Not sure if you're interested in updates to it (given it was for a one-off migration), but just in case - here's a small patch.

Cheers,
Andrew