### PR TITLE
Fix mysql's tinyint(1) type not being recongized as boolean

### DIFF
--- a/db_converter.py
+++ b/db_converter.py
@@ -110,7 +110,7 @@ def parse(input_filename, output_filename):
                 # See if it needs type conversion
                 final_type = None
                 set_sequence = None
-                if type == "tinyint(":
+                if type.startswith("tinyint("):
                     type = "int4"
                     set_sequence = True
                     final_type = "boolean"


### PR DESCRIPTION
The previous commit seemed to have broken the checking for `boolean` type, fixed it by replace `==` with  `startswith()`.