### PR TITLE
"FROM" in "SELECT setval..." missed to surround caps'ed tablename with double quotes

### DIFF
--- a/db_converter.py
+++ b/db_converter.py
@@ -158,7 +158,7 @@ def parse(input_filename, output_filename):
                 # ID fields need sequences [if they are integers?]
                 if name == "id" and set_sequence is True:
                     sequence_lines.append("CREATE SEQUENCE %s_id_seq" % (current_table))
-                    sequence_lines.append("SELECT setval('%s_id_seq', max(id)) FROM %s" % (current_table, current_table))
+                    sequence_lines.append("SELECT setval('%s_id_seq', max(id)) FROM \"%s\"" % (current_table, current_table))
                     sequence_lines.append("ALTER TABLE \"%s\" ALTER COLUMN \"id\" SET DEFAULT nextval('%s_id_seq')" % (current_table, current_table))
                 # Record it
                 creation_lines.append('"%s" %s %s' % (name, type, extra))


### PR DESCRIPTION
db_converter.py missed to surround caps'ed table name with double-quotes.
Thus PG considered it as lowercase (default bahavior) and was unable to find it.
It got my conversion job to crash.
The job now succeeds. Helpful for others :)
