### PR TITLE
fix UnicodeEncodeError: 'ascii' codec can't encode characters

### DIFF
--- a/db_converter.py
+++ b/db_converter.py
@@ -10,6 +10,8 @@ mysqldump --compatible=postgresql --default-character-set=utf8 -r databasename.m
 
 import re
 import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
 import os
 import time
 import subprocess


### PR DESCRIPTION
 fix UnicodeEncodeError: 'ascii' codec can't encode characters in position x-y: ordinal not in range(128)